### PR TITLE
Prevent Github throttling

### DIFF
--- a/rsgcore.yaml
+++ b/rsgcore.yaml
@@ -94,6 +94,9 @@ tasks:
     dest: ./resources/[standalone]/menu_base
     ref: main
     src: https://github.com/Rexshack-RedM/menu_base
+    
+  - action: waste_time # prevent github throttling
+    seconds: 10
 
   # Download RSGCore resources
   
@@ -221,6 +224,9 @@ tasks:
     src: https://github.com/Rexshack-RedM/rsg-pets
     ref: main
     dest: ./resources/[framework]/rsg-pets
+    
+  - action: waste_time # prevent github throttling
+    seconds: 10
     
   - action: download_github
     src: https://github.com/Rexshack-RedM/rsg-storage
@@ -391,6 +397,9 @@ tasks:
     dest: ./resources/[framework]/rsg-wholesaletrader
     ref: main
     src: https://github.com/Rexshack-RedM/rsg-wholesaletrader
+    
+  - action: waste_time # prevent github throttling
+    seconds: 10
     
   - action: download_github
     dest: ./resources/[framework]/rsg-npcs


### PR DESCRIPTION
Tested, can now download all resources

  - action: waste_time # prevent github throttling
    seconds: 10